### PR TITLE
More specific typings for Heading level attribute

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module "storyblok-rich-text-react-renderer" {
       ) => JSX.Element | null;
       [NODE_HEADING]?: (
         children: ReactNode,
-        props: { level: number }
+        props: { level: 1 | 2 | 3 | 4 | 5 | 6 }
       ) => JSX.Element | null;
       [NODE_HR]?: () => JSX.Element | null;
       [NODE_IMAGE]?: (


### PR DESCRIPTION
Hi!

In reality, headings can't be any any number other than 1 to 6.
This small PR makes it possible to use `level` directly in strongly typed props:

```tsx
const variant = {
  [1]: 'title',
  [2]: 'big',
  [3]: 'body',
  [4]: 'regular',
  [5]: 'small',
  [6]: 'caps',
} as const

<Text as={`h${level}`} variant={variant[level]}>
```