### PR TITLE
refactor: export additional types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module "storyblok-rich-text-react-renderer" {
     };
     defaultBlokResolver?: (
       name: string,
-      props: Record<string, unknown>
+      props: Record<string, unknown> & { _uid: string }
     ) => JSX.Element | null;
     markResolvers?: {
       [MARK_BOLD]?: (children: ReactNode) => JSX.Element | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "storyblok-rich-text-react-renderer" {
   import { ReactNode } from "react";
 
-  type StoryblokRichtextContentType =
+  export type StoryblokRichtextContentType =
     | "heading"
     | "code_block"
     | "paragraph"
@@ -14,7 +14,7 @@ declare module "storyblok-rich-text-react-renderer" {
     | "image"
     | "blok";
 
-  type StoryblokRichtextMark =
+  export type StoryblokRichtextMark =
     | "bold"
     | "italic"
     | "strike"
@@ -23,7 +23,7 @@ declare module "storyblok-rich-text-react-renderer" {
     | "link"
     | "styled";
 
-  type StoryblokRichtextContent = {
+  export type StoryblokRichtextContent = {
     type: StoryblokRichtextContentType;
     attrs?: {
       level?: number;
@@ -51,7 +51,7 @@ declare module "storyblok-rich-text-react-renderer" {
     content: StoryblokRichtextContent[];
   };
 
-  type StoryblokRichtext = {
+  export type StoryblokRichtext = {
     type: "doc";
     content: StoryblokRichtextContent[];
   };


### PR DESCRIPTION
I've just noticed that I was replicating code just to use some of the types already declared in the library. These exported types could be useful to type-check a RichText component props, for example.