### PR TITLE
chore: include types for links custom attributes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,12 @@
 declare module "storyblok-rich-text-react-renderer" {
   import { ReactNode } from "react";
 
+  type LinkCustomAttributes = {
+    rel?: string;
+    title?: string;
+    [key: string]: any;
+  };
+
   export type StoryblokRichtextContentType =
     | "heading"
     | "code_block"
@@ -54,6 +60,7 @@ declare module "storyblok-rich-text-react-renderer" {
         class?: string;
         color?: string;
         id?: string;
+        custom?: LinkCustomAttributes;
       };
     }[];
     text?: string;
@@ -114,6 +121,7 @@ declare module "storyblok-rich-text-react-renderer" {
           target?: string;
           anchor?: string;
           uuid?: string;
+          custom?: LinkCustomAttributes;
         }
       ) => JSX.Element | null;
       [MARK_STYLED]?: (


### PR DESCRIPTION
## What

Update types so link's custom attributes get taken into account.

## Why

[Default `RichTextResolver`](https://github.com/storyblok/storyblok-js-client/blob/main/src/schema.ts#L146) takes custom attributes for links like `rel` into account. Those will already be provided to your library so it would be nice to be able to use them while defining a `MARK_LINK` resolver.