### PR TITLE
textStyleMarkResolver implementation that avoids hydration errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,4 @@ Default node resolvers:
 - 2.7.0 — Add NODE_EMOJI, MARK_SUBSTRING, MARK_SUPERSTRING, MARK_HIGHLIGHT and MARK_TEXT_STYLE resolvers
 - 2.8.0 — Add MARK_ANCHOR resolver
 - 2.9.0 - Add type definition for custom link attributes in MARK_LINK
+- 2.9.1 - Safer implementation of textStyleMarkResolver

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,12 @@
 declare module "storyblok-rich-text-react-renderer" {
   import { ReactNode } from "react";
 
+  type LinkCustomAttributes = {
+    rel?: string;
+    title?: string;
+    [key: string]: any;
+  };
+
   export type StoryblokRichtextContentType =
     | "heading"
     | "code_block"
@@ -54,6 +60,7 @@ declare module "storyblok-rich-text-react-renderer" {
         class?: string;
         color?: string;
         id?: string;
+        custom?: LinkCustomAttributes;
       };
     }[];
     text?: string;
@@ -114,6 +121,7 @@ declare module "storyblok-rich-text-react-renderer" {
           target?: string;
           anchor?: string;
           uuid?: string;
+          custom?: LinkCustomAttributes;
         }
       ) => JSX.Element | null;
       [MARK_STYLED]?: (

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ const highlightMarkResolver = (children, attrs) => {
 }
 
 const textStyleMarkResolver = (children, attrs) => {
-    const props = attrs ? { style: { color: attrs.color } } : {};
+    const props = attrs?.color ? { style: { color: attrs.color } } : {};
     return React.createElement('span', props, children);
 }
 


### PR DESCRIPTION
Hello 👋🏻 

I've been getting some hydration errors on this app I worked on that uses your library and, even though the root reason for them to exist is not mainly connected to your library (more on that later), I thought it would be nice if we could avoid them without the necessity of custom render options. So I took the liberty of open this PR that updates `textStyleMarkResolver` by preventing the creation of _React_ elements that include `{ style: { color: '' } }` as the resulting DOM will not include a `style="color: ` on such cases, which causing hydration errors.

**Context**
For some reason I couldn't figure it out and therefore prevent, storyblok sometimes send rich text content text style markers without any color associated with it 🤷🏻 

With the current implementation of `textStyleMarkResolver`, the React representation for such elements end being:

`React.createElement('span', { props: { style: { color: '' } } }, 'some text')`

While in the DOM we have

`<span>some text</span>`

Ideally storyblok wouldn't not send rich text content in such weird state but I think we could be safer here as resolver for _text style markers_ defined in [`storyblok-js-client` is](https://github.com/storyblok/storyblok-js-client/blob/main/src/schema.ts#L228).

Let me know what you think :)

Cheers 🇧🇷 